### PR TITLE
Added auto approve option to custom apply tasks

### DIFF
--- a/plugin/src/main/groovy/dk/danskespil/gradle/plugins/terraform/tasks/Apply.groovy
+++ b/plugin/src/main/groovy/dk/danskespil/gradle/plugins/terraform/tasks/Apply.groovy
@@ -1,5 +1,6 @@
 package dk.danskespil.gradle.plugins.terraform.tasks
 
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
@@ -13,9 +14,17 @@ class Apply extends TerraformBaseTask {
     @InputFile
     File plan
 
+    @Optional
+    @Input
+    boolean autoApprove = false
+
     @TaskAction
     action() {
         commandLine.addToEnd('terraform', 'apply')
+
+        if (autoApprove) {
+            commandLine.addToEnd('-auto-approve')
+        }
 
         if (plan) {
             commandLine.addToEnd(plan.name)

--- a/plugin/src/test/groovy/dk/danskespil/gradle/plugins/terraform/tasks/ApplyTest.groovy
+++ b/plugin/src/test/groovy/dk/danskespil/gradle/plugins/terraform/tasks/ApplyTest.groovy
@@ -55,4 +55,44 @@ class ApplyTest extends BaseSpecification {
         build.output.contains('terraform apply plan.bin')
     }
 
+    def "When calling custom terraform apply task, you can configure auto approval"() {
+        given:
+        buildFile << """
+          plugins {
+            id 'dk.danskespil.gradle.plugins.terraform'
+
+          }
+          task cut(type: dk.danskespil.gradle.plugins.terraform.tasks.Apply) {
+            autoApprove = true
+          }
+        """
+
+        when:
+        def build = buildWithTasks(':cut')
+
+        then:
+        build.output.contains('terraform apply -auto-approve')
+    }
+
+    def "When calling custom terraform apply task, you can configure auto approval and set plan in correct order"() {
+        given:
+        buildFile << """
+          plugins {
+            id 'dk.danskespil.gradle.plugins.terraform'
+
+          }
+          task cut(type: dk.danskespil.gradle.plugins.terraform.tasks.Apply) {
+            autoApprove = true
+            plan = file('plan.bin')
+          }
+        """
+        createPathInTemporaryFolder('plan.bin') << "binary-content"
+
+        when:
+        def build = buildWithTasks(':cut')
+
+        then:
+        build.output.contains('terraform apply -auto-approve plan.bin')
+    }
+
 }


### PR DESCRIPTION
I'm using terraform as a step in between other automation, so I don't want it to require user input when applying the generated plan. This allows someone to set the '-auto-approve' flag on the apply command.

Not sure your thoughts on this, looking for feedback. 

Thanks.