### PR TITLE
Support variables and variable files in Plan and Validate tasks.

### DIFF
--- a/plugin/src/main/groovy/dk/danskespil/gradle/plugins/terraform/tasks/Apply.groovy
+++ b/plugin/src/main/groovy/dk/danskespil/gradle/plugins/terraform/tasks/Apply.groovy
@@ -32,6 +32,7 @@ class Apply extends TerraformBaseTask {
 
         executor.executeExecSpec(this, { ExecSpec e ->
             e.commandLine this.commandLine
+            e.workingDir project.projectDir
         })
     }
 

--- a/plugin/src/main/groovy/dk/danskespil/gradle/plugins/terraform/tasks/Get.groovy
+++ b/plugin/src/main/groovy/dk/danskespil/gradle/plugins/terraform/tasks/Get.groovy
@@ -15,6 +15,7 @@ class Get extends TerraformBaseTask {
 
         executor.executeExecSpec(this, { ExecSpec e ->
             e.commandLine this.commandLine
+            e.workingDir project.projectDir
         })
     }
 

--- a/plugin/src/main/groovy/dk/danskespil/gradle/plugins/terraform/tasks/Init.groovy
+++ b/plugin/src/main/groovy/dk/danskespil/gradle/plugins/terraform/tasks/Init.groovy
@@ -15,6 +15,7 @@ class Init extends TerraformBaseTask {
 
         executor.executeExecSpec(this, { ExecSpec e ->
             e.commandLine this.commandLine
+            e.workingDir project.projectDir
         })
     }
 

--- a/plugin/src/main/groovy/dk/danskespil/gradle/plugins/terraform/tasks/Plan.groovy
+++ b/plugin/src/main/groovy/dk/danskespil/gradle/plugins/terraform/tasks/Plan.groovy
@@ -8,7 +8,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecSpec
 
-class Plan extends TerraformBaseTask
+class Plan extends TerraformBaseTask implements TerraformVariables
 {
     // These inputfiles are the same for Validate and Plan
     @InputFiles
@@ -29,7 +29,7 @@ class Plan extends TerraformBaseTask
     @TaskAction
     action() {
         commandLine.addToEnd('terraform', 'plan')
-
+        addVariablesToEnd(commandLine)
         if (out) {
             commandLine.addToEnd("-out=${out.name}")
         }
@@ -42,6 +42,7 @@ class Plan extends TerraformBaseTask
         echoOutputHereToo.withStream { os ->
             executor.executeExecSpec(this, { ExecSpec e ->
                 e.commandLine this.commandLine
+                e.workingDir project.projectDir
                 e.standardOutput = os
             })
         }

--- a/plugin/src/main/groovy/dk/danskespil/gradle/plugins/terraform/tasks/TerraformVariables.groovy
+++ b/plugin/src/main/groovy/dk/danskespil/gradle/plugins/terraform/tasks/TerraformVariables.groovy
@@ -1,0 +1,31 @@
+package dk.danskespil.gradle.plugins.terraform.tasks
+
+import dk.danskespil.gradle.task.helpers.CommandLine
+
+trait TerraformVariables {
+    Map<String, String> vars = [:]
+    List<File> varfiles = []
+
+    void var(String key, String value) {
+        vars[key] = value
+        if (this.hasProperty('inputs')) {
+            inputs.property(key, value)
+        }
+    }
+
+    void varfile(File file) {
+        varfiles << file
+        if (this.hasProperty('inputs')) {
+            inputs.file(file)
+        }
+    }
+
+    void addVariablesToEnd(CommandLine commandLine) {
+        varfiles.each {
+            commandLine.addToEnd("-var-file=${it}")
+        }
+        vars.each { key, value ->
+            commandLine.addToEnd('-var', "${key}=${value}")
+        }
+    }
+}

--- a/plugin/src/main/groovy/dk/danskespil/gradle/plugins/terraform/tasks/Validate.groovy
+++ b/plugin/src/main/groovy/dk/danskespil/gradle/plugins/terraform/tasks/Validate.groovy
@@ -10,7 +10,7 @@ import org.gradle.process.ExecSpec
  * Wraps cli terraform validate
  */
 
-class Validate extends TerraformBaseTask {
+class Validate extends TerraformBaseTask implements TerraformVariables {
     // These inputfiles are the same for Validate and Plan
     @OutputFiles
     FileCollection oTerraformFiles = project.fileTree('.').include('*.tf').include('*.tpl')
@@ -20,9 +20,11 @@ class Validate extends TerraformBaseTask {
     @TaskAction
     action() {
         commandLine.addToEnd('terraform', 'validate')
+        addVariablesToEnd(commandLine)
 
         executor.executeExecSpec(this, { ExecSpec e ->
             e.commandLine this.commandLine
+            e.workingDir project.projectDir
         })
     }
 


### PR DESCRIPTION
Support variables and variable files in Plan and Validate tasks using the -var and -var-file arguments.

I also needed to set the working dir for the terraform execution to the project dir so in my multi-project scenario each project saw it's own terraform files. I use separate states per project to isolate different parts of the infrastructure. Let me know if there is a better/different way to solve this.

Fixes #6 